### PR TITLE
Layer.FromFiles

### DIFF
--- a/System.Containers/Layer.cs
+++ b/System.Containers/Layer.cs
@@ -11,10 +11,6 @@ public record struct Layer
 
     public static Layer FromDirectory(string directory, string containerPath)
     {
-        // Docker treats a COPY instruction that copies to a path like `/app` by
-        // including `app/` as a directory, with no leading slash. Emulate that here.
-        containerPath = containerPath.TrimStart(new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
-
         DirectoryInfo di = new(directory);
 
         IEnumerable<(string path, string containerPath)> fileList = 
@@ -49,7 +45,11 @@ public record struct Layer
             {
                 foreach (var item in fileList)
                 {
-                    writer.WriteEntry(item.path, item.containerPath);
+                    // Docker treats a COPY instruction that copies to a path like `/app` by
+                    // including `app/` as a directory, with no leading slash. Emulate that here.
+                    string containerPath = item.containerPath.TrimStart(PathSeparators);
+
+                    writer.WriteEntry(item.path, containerPath);
                 }
             }
 
@@ -82,4 +82,7 @@ public record struct Layer
 
         return l;
     }
+
+    private readonly static char[] PathSeparators = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
 }

--- a/Test.System.Containers.Filesystem/LayerEndToEnd.cs
+++ b/Test.System.Containers.Filesystem/LayerEndToEnd.cs
@@ -1,4 +1,4 @@
-﻿using System.Containers;
+using System.Containers;
 using System.Security.Cryptography;
 
 namespace Test.System.Containers.Filesystem;
@@ -7,12 +7,12 @@ namespace Test.System.Containers.Filesystem;
 public class LayerEndToEnd
 {
     [TestMethod]
-    public void SingleFile()
+    public void SingleFileInFolder()
     {
         using TransientTestFolder folder = new();
 
         string testFilePath = Path.Join(folder.Path, "TestFile.txt");
-        string testString = $"Test content for {nameof(SingleFile)}";
+        string testString = $"Test content for {nameof(SingleFileInFolder)}";
 
         File.WriteAllText(testFilePath, testString);
 
@@ -22,6 +22,45 @@ public class LayerEndToEnd
 
         //Assert.AreEqual("application/vnd.oci.image.layer.v1.tar", l.Descriptor.MediaType); // TODO: configurability
         Assert.AreEqual(2048, l.Descriptor.Size);
+        //Assert.AreEqual("sha256:26140bc75f2fcb3bf5da7d3b531d995c93d192837e37df0eb5ca46e2db953124", l.Descriptor.Digest); // TODO: determinism!
+
+        Assert.AreEqual(l.Descriptor.Size, new FileInfo(l.BackingFile).Length);
+
+        byte[] hashBytes;
+
+        using (SHA256 hasher = SHA256.Create())
+        using (FileStream fs = File.OpenRead(l.BackingFile))
+        {
+            hashBytes = hasher.ComputeHash(fs);
+        }
+
+        Assert.AreEqual(Convert.ToHexString(hashBytes), l.Descriptor.Digest.Substring("sha256:".Length), ignoreCase: true);
+    }
+
+    [TestMethod]
+    public void TwoFilesInTwoFolders()
+    {
+        using TransientTestFolder folder = new();
+
+        string testFilePath = Path.Join(folder.Path, "TestFile.txt");
+        string testString = $"Test content for {nameof(TwoFilesInTwoFolders)}";
+        File.WriteAllText(testFilePath, testString);
+
+        using TransientTestFolder folder2 = new();
+        string testFilePath2 = Path.Join(folder2.Path, "TestFile.txt");
+        string testString2 = $"Test content 2 for {nameof(TwoFilesInTwoFolders)}";
+        File.WriteAllText(testFilePath2, testString2);
+
+        Layer l = Layer.FromFiles(new[]
+        {
+            (testFilePath,  "/app/TestFile.txt"),
+            (testFilePath2, "/app/subfolder/TestFile.txt"),
+        });
+
+        Console.WriteLine(l.Descriptor);
+
+        //Assert.AreEqual("application/vnd.oci.image.layer.v1.tar", l.Descriptor.MediaType); // TODO: configurability
+        Assert.AreEqual(3072, l.Descriptor.Size);
         //Assert.AreEqual("sha256:26140bc75f2fcb3bf5da7d3b531d995c93d192837e37df0eb5ca46e2db953124", l.Descriptor.Digest); // TODO: determinism!
 
         Assert.AreEqual(l.Descriptor.Size, new FileInfo(l.BackingFile).Length);


### PR DESCRIPTION
Add a way to specify a list of files to put in the layer, which is more in line with how MSBuild's `ITaskItem[]` will work.