### PR TITLE
Clean up containers

### DIFF
--- a/Test.System.Containers.Filesystem/DockerRegistryManager.cs
+++ b/Test.System.Containers.Filesystem/DockerRegistryManager.cs
@@ -17,7 +17,7 @@ public class DockerRegistryManager
     {
         Console.WriteLine(nameof(StartAndPopulateDockerRegistry));
 
-        ProcessStartInfo startRegistry = new("docker", "run --publish 5000:5000 --detach registry:2")
+        ProcessStartInfo startRegistry = new("docker", "run --rm --publish 5000:5000 --detach registry:2")
         {
             RedirectStandardOutput = true,
         };

--- a/Test.System.Containers.Filesystem/EndToEnd.cs
+++ b/Test.System.Containers.Filesystem/EndToEnd.cs
@@ -56,7 +56,7 @@ public class EndToEnd
 
         // Run the image
 
-        ProcessStartInfo runInfo = new("docker", $"run --tty localhost:5000/{NewImageName}:latest")
+        ProcessStartInfo runInfo = new("docker", $"run --rm --tty localhost:5000/{NewImageName}:latest")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,


### PR DESCRIPTION
Add --rm to tell Docker to delete the containers used in tests
after they exit, so running tests locally doesn't accumulate
containers.
