### PR TITLE
UX pass on containerize app 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,6 @@
         <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageVersion Include="coverlet.collector" Version="3.1.2" />
         <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
-        <PackageVersion Include="System.CommandLine">
-            <Version>2.0.0-beta4.22272.1</Version>
-        </PackageVersion>
+        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -1,0 +1,9 @@
+<Project>
+    <PropertyGroup>
+        <_RegistryPort>5010</_RegistryPort>
+    </PropertyGroup>
+    
+    <Target Name="StartDockerRegistry">
+        <Exec Command="docker run -d -p $(_RegistryPort):5000 --restart=always --name registry registry:2"/>
+    </Target>
+</Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -2,8 +2,39 @@
     <PropertyGroup>
         <_RegistryPort>5010</_RegistryPort>
     </PropertyGroup>
-    
+
     <Target Name="StartDockerRegistry">
-        <Exec Command="docker run -d -p $(_RegistryPort):5000 --restart=always --name registry registry:2"/>
+        <Exec Command="docker run -d -p $(_RegistryPort):5000 --restart=always --name registry registry:2" />
     </Target>
+
+    <Target Name="PreloadBaseImages">
+        <PropertyGroup>
+            <_MCR>mcr.microsoft.com</_MCR>
+            <_LocalRegistry>localhost:5010</_LocalRegistry>
+        </PropertyGroup>
+        <Exec Command="docker pull $(_MCR)/dotnet/runtime:6.0" />
+        <Exec Command="docker tag $(_MCR)/dotnet/runtime:6.0 $(_LocalRegistry)/dotnet/runtime:6.0" />
+        <Exec Command="docker push $(_LocalRegistry)/dotnet/runtime:6.0" />
+
+        <Exec Command="docker pull $(_MCR)/dotnet/runtime:7.0" />
+        <Exec Command="docker tag $(_MCR)/dotnet/runtime:7.0 $(_LocalRegistry)/dotnet/runtime:7.0" />
+        <Exec Command="docker push $(_LocalRegistry)/dotnet/runtime:7.0" />
+
+        <Exec Command="docker pull $(_MCR)/dotnet/sdk:6.0" />
+        <Exec Command="docker tag $(_MCR)/dotnet/sdk:6.0 $(_LocalRegistry)/dotnet/sdk:6.0" />
+        <Exec Command="docker push $(_LocalRegistry)/dotnet/sdk:6.0" />
+
+        <Exec Command="docker pull $(_MCR)/dotnet/sdk:7.0" />
+        <Exec Command="docker tag $(_MCR)/dotnet/sdk:7.0 $(_LocalRegistry)/dotnet/sdk:7.0" />
+        <Exec Command="docker push $(_LocalRegistry)/dotnet/sdk:7.0" />
+
+        <Exec Command="docker pull $(_MCR)/dotnet/aspnet:6.0" />
+        <Exec Command="docker tag $(_MCR)/dotnet/aspnet:6.0 $(_LocalRegistry)/dotnet/aspnet:6.0" />
+        <Exec Command="docker push $(_LocalRegistry)/dotnet/aspnet:6.0" />
+
+        <Exec Command="docker pull $(_MCR)/dotnet/aspnet:7.0" />
+        <Exec Command="docker tag $(_MCR)/dotnet/aspnet:7.0 $(_LocalRegistry)/dotnet/aspnet:7.0" />
+        <Exec Command="docker push $(_LocalRegistry)/dotnet/aspnet:7.0" />
+    </Target>
+
 </Project>

--- a/System.Containers.sln
+++ b/System.Containers.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.System.Containers.File
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "containerize", "containerize\containerize.csproj", "{151F7937-D2AF-4242-9B6D-81FD5228D132}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "containerize", "containerize\containerize.csproj", "{092C78D2-3A0A-453B-BF5C-962F2B370136}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/System.Containers.sln
+++ b/System.Containers.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.32710.52
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -10,8 +9,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.System.Containers.Filesystem", "Test.System.Containers.Filesystem\Test.System.Containers.Filesystem.csproj", "{CC249FAD-C24D-4B37-AF8F-FA05D0FD5620}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "containerize", "containerize\containerize.csproj", "{151F7937-D2AF-4242-9B6D-81FD5228D132}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "containerize", "containerize\containerize.csproj", "{092C78D2-3A0A-453B-BF5C-962F2B370136}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -38,8 +38,6 @@ public record struct Registry(Uri BaseUri)
             throw new NotImplementedException($"Do not understand the mediaType {manifest["mediaType"]}");
         }
 
-        Console.WriteLine("Got manifest");
-        Console.WriteLine(s);
         JsonNode? config = manifest["config"];
         Debug.Assert(config is not null);
         Debug.Assert(((string?)config["mediaType"]) == DockerContainerV1);

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -21,6 +21,8 @@ public record struct Registry(Uri BaseUri)
     {
         using HttpClient client = GetClient();
 
+        Console.WriteLine($"Reading manifest for {name}:{reference}");
+
         var response = await client.GetAsync(new Uri(BaseUri, $"/v2/{name}/manifests/{reference}"));
 
         response.EnsureSuccessStatusCode();
@@ -36,6 +38,8 @@ public record struct Registry(Uri BaseUri)
             throw new NotImplementedException($"Do not understand the mediaType {manifest["mediaType"]}");
         }
 
+        Console.WriteLine("Got manifest");
+        Console.WriteLine(s);
         JsonNode? config = manifest["config"];
         Debug.Assert(config is not null);
         Debug.Assert(((string?)config["mediaType"]) == DockerContainerV1);

--- a/Test.System.Containers.Filesystem/EndToEnd.cs
+++ b/Test.System.Containers.Filesystem/EndToEnd.cs
@@ -33,7 +33,7 @@ public class EndToEnd
 
         // Build the image
 
-        Registry registry = new Registry(new Uri("http://localhost:5000"));
+        Registry registry = new Registry(new Uri("http://localhost:5010"));
 
         Image x = await registry.GetImageManifest(DockerRegistryManager.BaseImage, DockerRegistryManager.BaseImageTag);
 

--- a/Test.System.Containers.Filesystem/EndToEnd.cs
+++ b/Test.System.Containers.Filesystem/EndToEnd.cs
@@ -49,14 +49,14 @@ public class EndToEnd
 
         // pull it back locally
 
-        Process pull = Process.Start("docker", $"pull localhost:5000/{NewImageName}:latest");
+        Process pull = Process.Start("docker", $"pull localhost:5010/{NewImageName}:latest");
         Assert.IsNotNull(pull);
         await pull.WaitForExitAsync();
         Assert.AreEqual(0, pull.ExitCode);
 
         // Run the image
 
-        ProcessStartInfo runInfo = new("docker", $"run --tty localhost:5000/{NewImageName}:latest")
+        ProcessStartInfo runInfo = new("docker", $"run --tty localhost:5010/{NewImageName}:latest")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/containerize/Properties/launchSettings.json
+++ b/containerize/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "containerize": {
       "commandName": "Project",
-      "commandLineArgs": "--folder S:\\play\\helloworld6\\bin\\Debug\\net6.0\\publish --registry \"http://localhost:5000\" --base \"dotnet/sdk\" --baseTag \"6.0\" --entrypoint \"/app/helloworld6\" --name \"demo/container\""
+      "commandLineArgs": "--folder S:\\play\\helloworld6\\bin\\Debug\\net6.0\\publish --registry \"http://localhost:5010\" --base \"dotnet/sdk\" --baseTag \"6.0\" --entrypoint \"/app/helloworld6\" --name \"demo/container\""
     }
   }
 }


### PR DESCRIPTION
This adds

* 2 targets for starting a local Docker registry and preloading it with the dotnet base images
* unified references to port 5000 over to 5010 to get out of the default port selection for ASP.NET (and others)
* adds some logging while things are happening
* sets some defaults for common image properties so that we have a nicer-looking UI for the base case (demos better)
* preloads the generated image into the local Docker cache for easier running