### PR TITLE
Load image into local Docker without registry push/pull

### DIFF
--- a/System.Containers/Configuration.cs
+++ b/System.Containers/Configuration.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Containers;
+﻿using System.Diagnostics;
+
+namespace System.Containers;
 
 public static class Configuration
 {
@@ -19,6 +21,16 @@ public static class Configuration
             return tempPath;
         }
     }
+
+    public static string GetPathForDigest(string digest)
+    {
+        Debug.Assert(digest.StartsWith("sha256:"));
+
+        string contentHash = digest.Substring("sha256:".Length);
+
+        return GetPathForHash(contentHash);
+    }
+
 
     public static string GetPathForHash(string contentHash)
     {

--- a/System.Containers/Configuration.cs
+++ b/System.Containers/Configuration.cs
@@ -22,13 +22,25 @@ public static class Configuration
         }
     }
 
-    public static string GetPathForDigest(string digest)
+    public static string PathForDescriptor(Descriptor descriptor)
     {
+        string digest = descriptor.Digest;
+
         Debug.Assert(digest.StartsWith("sha256:"));
 
         string contentHash = digest.Substring("sha256:".Length);
 
-        return GetPathForHash(contentHash);
+        string extension = descriptor.MediaType switch
+        {
+            "application/vnd.docker.image.rootfs.diff.tar.gzip"
+            or "application/vnd.docker.image.rootfs.diff.tar"
+            or "application/vnd.oci.image.layer.v1.tar"
+            or "application/vnd.oci.image.layer.v1.tar+gzip"
+                => ".tar",
+            _ => throw new ArgumentException($"Unrecognized mediaType '{descriptor.MediaType}'")
+        };
+
+        return GetPathForHash(contentHash) + extension;
     }
 
 

--- a/System.Containers/Configuration.cs
+++ b/System.Containers/Configuration.cs
@@ -8,9 +8,25 @@ public static class Configuration
         get => Path.Combine(ArtifactRoot, "Content");
     }
 
+    public static string TempPath
+    {
+        get
+        {
+            string tempPath = Path.Join(ArtifactRoot, "Temp");
+
+            Directory.CreateDirectory(tempPath);
+
+            return tempPath;
+        }
+    }
+
     public static string GetPathForHash(string contentHash)
     {
         return Path.Combine(ContentRoot, contentHash);
     }
 
+    public static string GetTempFile()
+    {
+        return Path.Join(TempPath, Path.GetRandomFileName());
+    }
 }

--- a/System.Containers/Configuration.cs
+++ b/System.Containers/Configuration.cs
@@ -7,4 +7,10 @@ public static class Configuration
     {
         get => Path.Combine(ArtifactRoot, "Content");
     }
+
+    public static string GetPathForHash(string contentHash)
+    {
+        return Path.Combine(ContentRoot, contentHash);
+    }
+
 }

--- a/System.Containers/ContentStore.cs
+++ b/System.Containers/ContentStore.cs
@@ -2,7 +2,7 @@
 
 namespace System.Containers;
 
-public static class Configuration
+public static class ContentStore
 {
     public static string ArtifactRoot { get; set; } = Path.Combine(Path.GetTempPath(), "Containers");
     public static string ContentRoot

--- a/System.Containers/Image.cs
+++ b/System.Containers/Image.cs
@@ -23,6 +23,29 @@ public class Image
         this.originatingRegistry = registry;
     }
 
+    public IEnumerable<Descriptor> LayerDescriptors
+    {
+        get
+        {
+            JsonNode? layersNode = manifest["layers"];
+
+            if (layersNode is null)
+            {
+                throw new NotImplementedException("Tried to get layer information but there is no layer node?");
+            }
+
+            foreach (JsonNode? descriptorJson in layersNode.AsArray())
+            {
+                if (descriptorJson is null)
+                {
+                    throw new NotImplementedException("Null layer descriptor in the list?");
+                }
+
+                yield return descriptorJson.Deserialize<Descriptor>();
+            }
+        }
+    }
+
     public void AddLayer(Layer l)
     {
         newLayers.Add(l);

--- a/System.Containers/Image.cs
+++ b/System.Containers/Image.cs
@@ -10,14 +10,16 @@ public class Image
     public JsonNode manifest;
     public JsonNode config;
 
+    public readonly string OriginatingName;
     internal readonly Registry? originatingRegistry;
 
     internal List<Layer> newLayers = new();
 
-    public Image(JsonNode manifest, JsonNode config, Registry? registry)
+    public Image(JsonNode manifest, JsonNode config, string name, Registry? registry)
     {
         this.manifest = manifest;
         this.config = config;
+        this.OriginatingName = name;
         this.originatingRegistry = registry;
     }
 

--- a/System.Containers/Image.cs
+++ b/System.Containers/Image.cs
@@ -10,12 +10,15 @@ public class Image
     internal JsonNode manifest;
     internal JsonNode config;
 
+    internal readonly Registry? originatingRegistry;
+
     internal List<Layer> newLayers = new();
 
-    public Image(JsonNode manifest, JsonNode config)
+    public Image(JsonNode manifest, JsonNode config, Registry? registry)
     {
         this.manifest = manifest;
         this.config = config;
+        this.originatingRegistry = registry;
     }
 
     public void AddLayer(Layer l)

--- a/System.Containers/Image.cs
+++ b/System.Containers/Image.cs
@@ -7,8 +7,8 @@ namespace System.Containers;
 
 public class Image
 {
-    internal JsonNode manifest;
-    internal JsonNode config;
+    public JsonNode manifest;
+    public JsonNode config;
 
     internal readonly Registry? originatingRegistry;
 

--- a/System.Containers/Image.cs
+++ b/System.Containers/Image.cs
@@ -66,9 +66,18 @@ public class Image
 
     public string GetDigest(JsonNode json)
     {
+        string hashString;
+
+        hashString = GetSha(json);
+
+        return $"sha256:{hashString}";
+    }
+
+    public static string GetSha(JsonNode json)
+    {
         using SHA256 mySHA256 = SHA256.Create();
         byte[] hash = mySHA256.ComputeHash(Encoding.UTF8.GetBytes(json.ToJsonString()));
 
-        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 }

--- a/System.Containers/Image.cs
+++ b/System.Containers/Image.cs
@@ -30,7 +30,7 @@ public class Image
     }
 
     private void RecalculateDigest() {
-        manifest["config"]!["digest"] = GetSha(config);
+        manifest["config"]!["digest"] = GetDigest(config);
     }
 
     public void SetEntrypoint(string executable, string[]? args = null)
@@ -64,7 +64,7 @@ public class Image
         }
     }
 
-    public string GetSha(JsonNode json)
+    public string GetDigest(JsonNode json)
     {
         using SHA256 mySHA256 = SHA256.Create();
         byte[] hash = mySHA256.ComputeHash(Encoding.UTF8.GetBytes(json.ToJsonString()));

--- a/System.Containers/Layer.cs
+++ b/System.Containers/Layer.cs
@@ -33,7 +33,7 @@ public record struct Layer
         long fileSize;
         byte[] hash;
 
-        string tempTarballPath = Configuration.GetTempFile();
+        string tempTarballPath = ContentStore.GetTempFile();
         using (FileStream fs = File.Create(tempTarballPath))
         {
             // using (GZipStream gz = new(fs, CompressionMode.Compress)) // TODO: https://github.com/rainersigwald/containers/issues/29
@@ -66,9 +66,9 @@ public record struct Layer
             Digest = $"sha256:{contentHash}"
         };
 
-        string storedContent = Configuration.PathForDescriptor(descriptor);
+        string storedContent = ContentStore.PathForDescriptor(descriptor);
 
-        Directory.CreateDirectory(Configuration.ContentRoot);
+        Directory.CreateDirectory(ContentStore.ContentRoot);
 
         File.Move(tempTarballPath, storedContent, overwrite: true);
 

--- a/System.Containers/Layer.cs
+++ b/System.Containers/Layer.cs
@@ -63,7 +63,7 @@ public record struct Layer
 
         string contentHash = Convert.ToHexString(hash).ToLowerInvariant();
 
-        string storedContent = Path.Combine(Configuration.ContentRoot, contentHash);
+        string storedContent = Configuration.GetPathForHash(contentHash);
 
         Directory.CreateDirectory(Configuration.ContentRoot);
 

--- a/System.Containers/Layer.cs
+++ b/System.Containers/Layer.cs
@@ -59,7 +59,14 @@ public record struct Layer
 
         string contentHash = Convert.ToHexString(hash).ToLowerInvariant();
 
-        string storedContent = Configuration.GetPathForHash(contentHash);
+        Descriptor descriptor = new()
+        {
+            MediaType = "application/vnd.docker.image.rootfs.diff.tar", // TODO: configurable? gzip always?
+            Size = fileSize,
+            Digest = $"sha256:{contentHash}"
+        };
+
+        string storedContent = Configuration.PathForDescriptor(descriptor);
 
         Directory.CreateDirectory(Configuration.ContentRoot);
 
@@ -67,12 +74,7 @@ public record struct Layer
 
         Layer l = new()
         {
-            Descriptor = new()
-            {
-                MediaType = "application/vnd.docker.image.rootfs.diff.tar", // TODO: configurable? gzip always?
-                Size = fileSize,
-                Digest = $"sha256:{contentHash}"
-            },
+            Descriptor = descriptor,
             BackingFile = storedContent,
         };
 

--- a/System.Containers/Layer.cs
+++ b/System.Containers/Layer.cs
@@ -30,14 +30,10 @@ public record struct Layer
 
     public static Layer FromFiles(IEnumerable<(string path, string containerPath)> fileList)
     {
-        string tempPath = Path.Join(Configuration.ArtifactRoot, "Temp");
-
-        Directory.CreateDirectory(tempPath);
-
         long fileSize;
         byte[] hash;
 
-        string tempTarballPath = Path.Join(tempPath, Path.GetRandomFileName());
+        string tempTarballPath = Configuration.GetTempFile();
         using (FileStream fs = File.Create(tempTarballPath))
         {
             // using (GZipStream gz = new(fs, CompressionMode.Compress)) // TODO: https://github.com/rainersigwald/containers/issues/29

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -1,21 +1,56 @@
-﻿namespace System.Containers;
+﻿using System.Diagnostics;
+using System.Formats.Tar;
+using System.Text;
+
+namespace System.Containers;
 
 internal class LocalDocker
 {
     public async Task Load(Image x, string name, string baseName)
     {
-        // Populate local cache with all layer tarballs
+        // call `docker load` and get it ready to recieve input
+        ProcessStartInfo loadInfo = new("docker", $"load");
+        loadInfo.RedirectStandardInput = true;
+        loadInfo.RedirectStandardOutput = true;
+
+        using Process? loadProcess = Process.Start(loadInfo);
+
+        if (loadProcess is null)
+        {
+            throw new NotImplementedException("Failed creating docker process");
+        }
 
         // Create new stream tarball
 
+        await WriteImageToStream(x, name, baseName, loadProcess.StandardInput.BaseStream);
+
+        await loadProcess.WaitForExitAsync();
+
+
+
+        // give it a tag?
+    }
+
+    private static async Task WriteImageToStream(Image x, string name, string baseName, Stream imageStream)
+    {
+        // Populate local cache with all layer tarballs
+
+        TarWriter writer = new(imageStream, TarEntryFormat.Gnu, leaveOpen: true);
+
         // Feed each layer tarball into the stream
+
+        // add config
+        using (MemoryStream configStream = new MemoryStream(Encoding.UTF8.GetBytes(x.config.ToJsonString())))
+        {
+            GnuTarEntry configEntry = new(TarEntryType.RegularFile, $"{x.GetSha(x.config)}.json")
+            {
+                DataStream = configStream
+            };
+
+            writer.WriteEntry(configEntry); // TODO: asyncify these when API available (Preview 7)
+        }
 
         // Add manifest
 
-        // add config
-
-        // call `docker load`
-
-        // give it a tag?
     }
 }

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace System.Containers;
 
-internal class LocalDocker
+public class LocalDocker
 {
     public async Task Load(Image x, string name, string baseName)
     {
@@ -31,7 +31,7 @@ internal class LocalDocker
         // give it a tag?
     }
 
-    private static async Task WriteImageToStream(Image x, string name, string baseName, Stream imageStream)
+    public static async Task WriteImageToStream(Image x, string name, string baseName, Stream imageStream)
     {
         // Populate local cache with all layer tarballs
 

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -1,8 +1,8 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Formats.Tar;
-using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace System.Containers;
 
@@ -39,6 +39,7 @@ public class LocalDocker
 
 
         // Feed each layer tarball into the stream
+        JsonArray layerTarballPaths = new JsonArray();
 
         foreach (var layerJson in x.manifest["layers"].AsArray())
         {
@@ -52,13 +53,17 @@ public class LocalDocker
             string localPath = await x.originatingRegistry.Value.LocalFileForBlob(baseName, d);
 
             // Stuff that (uncompressed) tarball into the image tar stream
-            writer.WriteEntry(localPath, $"{d.Digest.Substring("sha256:".Length)}/layer.tar");
+            string layerTarballPath = $"{d.Digest.Substring("sha256:".Length)}/layer.tar";
+            writer.WriteEntry(localPath, layerTarballPath);
+            layerTarballPaths.Add(layerTarballPath);
         }
 
         // add config
+        string configTarballPath = $"{Image.GetSha(x.config)}.json";
+
         using (MemoryStream configStream = new MemoryStream(Encoding.UTF8.GetBytes(x.config.ToJsonString())))
         {
-            GnuTarEntry configEntry = new(TarEntryType.RegularFile, $"{Image.GetSha(x.config)}.json")
+            GnuTarEntry configEntry = new(TarEntryType.RegularFile, configTarballPath)
             {
                 DataStream = configStream
             };
@@ -67,5 +72,26 @@ public class LocalDocker
         }
 
         // Add manifest
+        JsonArray tagsNode = new()
+        {
+            name + ":latest" // TODO: do something else here?
+        };
+
+        JsonNode manifestNode = new JsonArray(new JsonObject
+        {
+            { "Config", configTarballPath },
+            { "RepoTags", tagsNode },
+            { "Layers", layerTarballPaths }
+        });
+
+        using (MemoryStream manifestStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestNode.ToJsonString())))
+        {
+            GnuTarEntry manifestEntry = new(TarEntryType.RegularFile, "manifest.json")
+            {
+                DataStream = manifestStream
+            };
+
+            writer.WriteEntry(manifestEntry); // TODO: asyncify these when API available (Preview 7)
+        }
     }
 }

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -39,10 +39,8 @@ public class LocalDocker
         // Feed each layer tarball into the stream
         JsonArray layerTarballPaths = new JsonArray();
 
-        foreach (var layerJson in x.manifest["layers"].AsArray())
+        foreach (var d in x.LayerDescriptors)
         {
-            Descriptor d = layerJson.Deserialize<Descriptor>();
-
             if (!x.originatingRegistry.HasValue)
             {
                 throw new NotImplementedException("Need a good error for 'couldn't download a thing because no link to registry'");

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -24,14 +24,14 @@ public class LocalDocker
 
         // Create new stream tarball
 
-        await WriteImageToStream(x, name, baseName, loadProcess.StandardInput.BaseStream);
+        await WriteImageToStream(x, name, loadProcess.StandardInput.BaseStream);
 
         loadProcess.StandardInput.Close();
 
         await loadProcess.WaitForExitAsync();
     }
 
-    public static async Task WriteImageToStream(Image x, string name, string baseName, Stream imageStream)
+    public static async Task WriteImageToStream(Image x, string name, Stream imageStream)
     {
         TarWriter writer = new(imageStream, TarEntryFormat.Gnu, leaveOpen: true);
 
@@ -48,7 +48,7 @@ public class LocalDocker
                 throw new NotImplementedException("Need a good error for 'couldn't download a thing because no link to registry'");
             }
 
-            string localPath = await x.originatingRegistry.Value.DownloadBlob(baseName, d);
+            string localPath = await x.originatingRegistry.Value.DownloadBlob(x.OriginatingName, d);
 
             // Stuff that (uncompressed) tarball into the image tar stream
             string layerTarballPath = $"{d.Digest.Substring("sha256:".Length)}/layer.tar";

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -8,7 +8,7 @@ namespace System.Containers;
 
 public class LocalDocker
 {
-    public async Task Load(Image x, string name, string baseName)
+    public static async Task Load(Image x, string name, string baseName)
     {
         // call `docker load` and get it ready to recieve input
         ProcessStartInfo loadInfo = new("docker", $"load");
@@ -26,11 +26,9 @@ public class LocalDocker
 
         await WriteImageToStream(x, name, baseName, loadProcess.StandardInput.BaseStream);
 
+        loadProcess.StandardInput.Close();
+
         await loadProcess.WaitForExitAsync();
-
-
-
-        // give it a tag?
     }
 
     public static async Task WriteImageToStream(Image x, string name, string baseName, Stream imageStream)

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -48,7 +48,7 @@ public class LocalDocker
                 throw new NotImplementedException("Need a good error for 'couldn't download a thing because no link to registry'");
             }
 
-            string localPath = await x.originatingRegistry.Value.LocalFileForBlob(baseName, d);
+            string localPath = await x.originatingRegistry.Value.DownloadBlob(baseName, d);
 
             // Stuff that (uncompressed) tarball into the image tar stream
             string layerTarballPath = $"{d.Digest.Substring("sha256:".Length)}/layer.tar";

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -42,7 +42,7 @@ public class LocalDocker
         // add config
         using (MemoryStream configStream = new MemoryStream(Encoding.UTF8.GetBytes(x.config.ToJsonString())))
         {
-            GnuTarEntry configEntry = new(TarEntryType.RegularFile, $"{x.GetSha(x.config)}.json")
+            GnuTarEntry configEntry = new(TarEntryType.RegularFile, $"{x.GetDigest(x.config)}.json")
             {
                 DataStream = configStream
             };

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -42,7 +42,7 @@ public class LocalDocker
         // add config
         using (MemoryStream configStream = new MemoryStream(Encoding.UTF8.GetBytes(x.config.ToJsonString())))
         {
-            GnuTarEntry configEntry = new(TarEntryType.RegularFile, $"{x.GetDigest(x.config)}.json")
+            GnuTarEntry configEntry = new(TarEntryType.RegularFile, $"{Image.GetSha(x.config)}.json")
             {
                 DataStream = configStream
             };

--- a/System.Containers/LocalDocker.cs
+++ b/System.Containers/LocalDocker.cs
@@ -1,0 +1,21 @@
+﻿namespace System.Containers;
+
+internal class LocalDocker
+{
+    public async Task Load(Image x, string name, string baseName)
+    {
+        // Populate local cache with all layer tarballs
+
+        // Create new stream tarball
+
+        // Feed each layer tarball into the stream
+
+        // Add manifest
+
+        // add config
+
+        // call `docker load`
+
+        // give it a tag?
+    }
+}

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -54,7 +54,7 @@ public record struct Registry(Uri BaseUri)
 
     public async Task<string> LocalFileForBlob(string name, Descriptor descriptor)
     {
-        string localPath = Configuration.GetPathForDigest(descriptor.Digest);
+        string localPath = Configuration.PathForDescriptor(descriptor);
 
         if (File.Exists(localPath))
         {

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -53,7 +53,13 @@ public record struct Registry(Uri BaseUri)
         return new Image(manifest, configDoc, this);
     }
 
-    public async Task<string> LocalFileForBlob(string name, Descriptor descriptor)
+    /// <summary>
+    /// Ensure a blob associated with <paramref name="name"/> from the registry is available locally.
+    /// </summary>
+    /// <param name="name">Name of the associated image.</param>
+    /// <param name="descriptor"><see cref="Descriptor"/> that describes the blob.</param>
+    /// <returns>Local path to the (decompressed) blob content.</returns>
+    public async Task<string> DownloadBlob(string name, Descriptor descriptor)
     {
         string localPath = Configuration.PathForDescriptor(descriptor);
 

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -162,13 +162,13 @@ public record struct Registry(Uri BaseUri)
 
         using (MemoryStream stringStream = new MemoryStream(Encoding.UTF8.GetBytes(x.config.ToJsonString())))
         {
-            await UploadBlob(name, x.GetSha(x.config), stringStream);
+            await UploadBlob(name, x.GetDigest(x.config), stringStream);
         }
 
         HttpContent manifestUploadContent = new StringContent(x.manifest.ToJsonString());
         manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(DockerManifestV2);
 
-        var putResponse = await client.PutAsync(new Uri(BaseUri, $"/v2/{name}/manifests/{x.GetSha(x.manifest)}"), manifestUploadContent);
+        var putResponse = await client.PutAsync(new Uri(BaseUri, $"/v2/{name}/manifests/{x.GetDigest(x.manifest)}"), manifestUploadContent);
 
         string putresponsestr = await putResponse.Content.ReadAsStringAsync();
 

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -49,7 +49,7 @@ public record struct Registry(Uri BaseUri)
         Debug.Assert(configDoc is not null);
         //Debug.Assert(((string?)configDoc["mediaType"]) == DockerContainerV1);
 
-        return new Image(manifest, configDoc);
+        return new Image(manifest, configDoc, this);
     }
 
     public async Task Push(Layer layer, string name)

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -61,7 +61,7 @@ public record struct Registry(Uri BaseUri)
     /// <returns>Local path to the (decompressed) blob content.</returns>
     public async Task<string> DownloadBlob(string name, Descriptor descriptor)
     {
-        string localPath = Configuration.PathForDescriptor(descriptor);
+        string localPath = ContentStore.PathForDescriptor(descriptor);
 
         if (File.Exists(localPath))
         {
@@ -77,7 +77,7 @@ public record struct Registry(Uri BaseUri)
 
         response.EnsureSuccessStatusCode();
 
-        string tempTarballPath = Configuration.GetTempFile();
+        string tempTarballPath = ContentStore.GetTempFile();
         using (FileStream fs = File.Create(tempTarballPath))
         {
             Stream? gzs = null;

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -173,12 +173,9 @@ public record struct Registry(Uri BaseUri)
     {
         using HttpClient client = GetClient();
 
-        foreach (var layerJson in x.manifest["layers"].AsArray())
+        foreach (var descriptor in x.LayerDescriptors)
         {
-            JsonNode? layerValue = JsonValue.Parse(layerJson.ToJsonString());
-
-            JsonNode? digestNode = layerValue["digest"];
-            string digest = digestNode.ToString();
+            string digest = descriptor.Digest;
 
             if (await BlobAlreadyUploaded(name, digest, client))
             {

--- a/System.Containers/Registry.cs
+++ b/System.Containers/Registry.cs
@@ -50,7 +50,7 @@ public record struct Registry(Uri BaseUri)
         Debug.Assert(configDoc is not null);
         //Debug.Assert(((string?)configDoc["mediaType"]) == DockerContainerV1);
 
-        return new Image(manifest, configDoc, this);
+        return new Image(manifest, configDoc, name, this);
     }
 
     /// <summary>

--- a/Test.System.Containers.Filesystem/LayerEndToEnd.cs
+++ b/Test.System.Containers.Filesystem/LayerEndToEnd.cs
@@ -84,9 +84,9 @@ public class LayerEndToEnd
     {
         testSpecificArtifactRoot = new();
 
-        priorArtifactRoot = Configuration.ArtifactRoot;
+        priorArtifactRoot = ContentStore.ArtifactRoot;
 
-        Configuration.ArtifactRoot = testSpecificArtifactRoot.Path;
+        ContentStore.ArtifactRoot = testSpecificArtifactRoot.Path;
     }
 
     [TestCleanup]
@@ -95,7 +95,7 @@ public class LayerEndToEnd
         testSpecificArtifactRoot?.Dispose();
         if (priorArtifactRoot is not null)
         {
-            Configuration.ArtifactRoot = priorArtifactRoot;
+            ContentStore.ArtifactRoot = priorArtifactRoot;
         }
     }
 }

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -75,7 +75,9 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
 
     x.SetEntrypoint(entrypoint);
 
-    await PushToLocalDockerViaRegistry(registryName, baseName, imageName, registry, x);
+    //await PushToLocalDockerViaRegistry(registryName, baseName, imageName, registry, x);
+    using FileStream tarStream = new FileStream("test.tar", FileMode.OpenOrCreate);
+    await LocalDocker.WriteImageToStream(x, imageName, baseName, tarStream);
 
     Console.WriteLine($"Loaded image into local Docker daemon. Use 'docker run --rm -it --name {imageName} {registryName}/{imageName}:latest' to run the application.");
 }

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -81,13 +81,10 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
 
     x.SetEntrypoint(entrypoint);
 
-    File.WriteAllTextAsync("manifest.json", x.manifest.ToJsonString(options));
-    File.WriteAllTextAsync("config.json", x.config.ToJsonString(options));
+    // File.WriteAllTextAsync("manifest.json", x.manifest.ToJsonString(options));
+    // File.WriteAllTextAsync("config.json", x.config.ToJsonString(options));
 
-    //await PushToLocalDockerViaRegistry(registryName, baseName, imageName, registry, x);
-
-    using FileStream tarStream = new FileStream("test.tar", FileMode.OpenOrCreate);
-    await LocalDocker.WriteImageToStream(x, imageName, baseName, tarStream);
+    await LocalDocker.Load(x, imageName, baseName);
 
     Console.WriteLine($"Loaded image into local Docker daemon. Use 'docker run --rm -it --name {imageName} {registryName}/{imageName}:latest' to run the application.");
 }

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -75,6 +75,13 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
 
     x.SetEntrypoint(entrypoint);
 
+    await PushToLocalDockerViaRegistry(registryName, baseName, imageName, registry, x);
+
+    Console.WriteLine($"Loaded image into local Docker daemon. Use 'docker run --rm -it --name {imageName} {registryName}/{imageName}:latest' to run the application.");
+}
+
+static async Task PushToLocalDockerViaRegistry(string registryName, string baseName, string imageName, Registry registry, Image x)
+{
     // Push the image back to the local registry
 
     await registry.Push(x, imageName, baseName);
@@ -83,7 +90,4 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
 
     var pullBase = System.Diagnostics.Process.Start("docker", $"pull {registryName}/{imageName}:latest");
     await pullBase.WaitForExitAsync();
-
-    Console.WriteLine($"Loaded image into local Docker daemon. Use 'docker run --rm -it --name {imageName} {registryName}/{imageName}:latest' to run the application.");
-
 }

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -80,9 +80,9 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
     Console.WriteLine($"Copying from {folder.FullName} to {workingDir}");
     Layer l = Layer.FromDirectory(folder.FullName, workingDir);
 
-    x.AddLayer(l);
+    //x.AddLayer(l);
 
-    x.SetEntrypoint(entrypoint);
+    //x.SetEntrypoint(entrypoint);
 
     //await PushToLocalDockerViaRegistry(registryName, baseName, imageName, registry, x);
     using FileStream tarStream = new FileStream("test.tar", FileMode.OpenOrCreate);

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -74,17 +74,18 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
         WriteIndented = true,
     };
 
-    File.WriteAllTextAsync("manifest.json", x.manifest.ToJsonString(options));
-    File.WriteAllTextAsync("config.json", x.config.ToJsonString(options));
-
     Console.WriteLine($"Copying from {folder.FullName} to {workingDir}");
     Layer l = Layer.FromDirectory(folder.FullName, workingDir);
 
-    //x.AddLayer(l);
+    x.AddLayer(l);
 
-    //x.SetEntrypoint(entrypoint);
+    x.SetEntrypoint(entrypoint);
+
+    File.WriteAllTextAsync("manifest.json", x.manifest.ToJsonString(options));
+    File.WriteAllTextAsync("config.json", x.config.ToJsonString(options));
 
     //await PushToLocalDockerViaRegistry(registryName, baseName, imageName, registry, x);
+
     using FileStream tarStream = new FileStream("test.tar", FileMode.OpenOrCreate);
     await LocalDocker.WriteImageToStream(x, imageName, baseName, tarStream);
 

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.CommandLine;
 using System.Containers;
+using System.Text.Json;
 
 var fileOption = new Argument<DirectoryInfo>(
     name: "folder",
@@ -67,6 +68,14 @@ async Task Containerize(DirectoryInfo folder, string workingDir, string registry
 
     Image x = await registry.GetImageManifest(baseName, baseTag);
     x.WorkingDirectory = workingDir;
+
+    JsonSerializerOptions options = new()
+    {
+        WriteIndented = true,
+    };
+
+    File.WriteAllTextAsync("manifest.json", x.manifest.ToJsonString(options));
+    File.WriteAllTextAsync("config.json", x.config.ToJsonString(options));
 
     Console.WriteLine($"Copying from {folder.FullName} to {workingDir}");
     Layer l = Layer.FromDirectory(folder.FullName, workingDir);

--- a/containerize/Properties/launchSettings.json
+++ b/containerize/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "containerize": {
       "commandName": "Project",
-      "commandLineArgs": "--folder S:\\play\\helloworld6\\bin\\Debug\\net6.0\\publish --registry \"http://localhost:5010\" --base \"dotnet/sdk\" --baseTag \"6.0\" --entrypoint \"/app/helloworld6\" --name \"demo/container\""
+      "commandLineArgs": "S:\\play\\container-demo\\bin\\Debug\\net6.0\\linux-x64\\ --registry localhost:5010 --base \"dotnet/runtime\" --baseTag \"6.0\" --entrypoint \"/app/container-demo\" --name \"showcase/demo\""
     }
   }
 }


### PR DESCRIPTION
Emit a tarball in a format like `docker save` emits, and make it so we can stream that into `docker load` in a subprocess to avoid the "push to a registry then pull from a registry" dance during inner loops.

Closes #19.