### PR TITLE
Use dotnet/runtime-deps as the base image for SelfContained scenarios

### DIFF
--- a/System.Containers.Tasks/build/System.Containers.Tasks.targets
+++ b/System.Containers.Tasks/build/System.Containers.Tasks.targets
@@ -2,8 +2,10 @@
     <Target Name="ComputeContainerConfig">
         <!-- Compute private defaults -->
         <PropertyGroup Condition="$(ContainerBaseImage) == ''">
+            <_IsSelfContained Condition="'$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true'">true</_IsSelfContained>
             <_ContainerBaseRegistry>https://mcr.microsoft.com</_ContainerBaseRegistry>
-            <_ContainerBaseImageName Condition="@(ProjectCapability->AnyHaveMetadataValue('Identity', 'AspNetCore'))">dotnet/aspnet</_ContainerBaseImageName>
+            <_ContainerBaseImageName Condition="'$(_IsSelfContained)' == 'true'">dotnet/runtime-deps</_ContainerBaseImageName>
+            <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == '' and @(ProjectCapability->AnyHaveMetadataValue('Identity', 'AspNetCore'))">dotnet/aspnet</_ContainerBaseImageName>
             <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == ''">dotnet/runtime</_ContainerBaseImageName>
             <_ContainerBaseImageTag>$(_TargetFrameworkVersionWithoutV)</_ContainerBaseImageTag>
         </PropertyGroup>


### PR DESCRIPTION
Self-contained applications only need the runtime-deps (regardless of aspnet-ed-ness) so we can use that base image as the default. This image has the same tags as the other base images, so it should be a safe change.