### PR TITLE
Signed official build in internal Azure DevOps

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.100-preview.6.22352.1
+        global-json-file: 'global.json' # in addition to the 6.0 we need for tests, install "latest"
     - name: Build
       run: dotnet build
     - name: Test

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 ﻿<Project>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core"  />
     <PackageReference Include="Nerdbank.GitVersioning"  />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <ItemGroup>
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
         <PackageVersion Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.109" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '7.0.100-preview.6.22352.1'
+    useGlobalJson: true
     includePreviewVersions: true
 
 - task: MicroBuildSigningPlugin@4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,42 @@
+trigger:
+- main
+
+parameters:
+  - name: SignType
+    type: string
+    default: test
+    values:
+      - real
+      - test
+
+pool:
+  name: VSEngSS-MicroBuild2022-1ES
+
+steps:
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '7.0.100-preview.6.22352.1'
+    includePreviewVersions: true
+
+- task: MicroBuildSigningPlugin@4
+  inputs:
+    signType: 'test'
+    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
+- task: MSBuild@1
+  inputs:
+    solution: '**/*.sln'
+    msbuildArchitecture: 'x64'
+    configuration: 'Release'
+    msbuildArguments: '-restore -bl:$(Build.StagingDirectory)\ContainersOfficialBuild.binlog -v:minimal'
+    maximumCpuCount: true
+
+- task: PublishPipelineArtifact@1
+  inputs:
+    targetPath: '$(Pipeline.Workspace)'
+    artifact: 'Everything'
+    publishLocation: 'pipeline'
+  condition: succeededOrFailed()
+
+- task: MicroBuildCleanup@1

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.100-preview.6.22352.1",
+    "allowPrerelease": true,
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
- Set up signed build with Azure Pipelines
- Update azure-pipelines.yml for Azure Pipelines
- Adopt MicroBuild.Core
- global.json with prerelease
- Always upload logs/bin
- Restore
- Minimal official build console output (binlog ftw)
- Save binlog to staging directory for upload
- Remove Pack target (we pack on build anyway)
