### PR TITLE
Add help documentation to repo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning"  />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" IncludeAssets="build; buildMultitargeting" />
   </ItemGroup>
 </Project>

--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -28,6 +28,7 @@
     <RepositoryUrl>https://github.com/rainersigwald/containers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>containers;docker;Microsoft.NET.Build.Containers</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <Content Include="build\Microsoft.NET.Build.Containers.props" Pack="true" PackagePath="build\" />
     <Content Include="build\Microsoft.NET.Build.Containers.targets" Pack="true" PackagePath="build\" />
+    <Content Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!-- This target adds all of our PackageReference and ProjectReference's runtime assets to our package output. -->

--- a/Microsoft.NET.Build.Containers/README.md
+++ b/Microsoft.NET.Build.Containers/README.md
@@ -15,4 +15,4 @@ Pushed container '<your app name>:<your app version>' to registry 'docker://'
 ...
 ```
 
-Out of the box, this package will infer a number of properties about the generated container image, including which base image to use, which version of that image to use, and where to push the generated image. You have control over all of these properties, however. You can read more about these customizations [here](https://github.com/rainersigwald/containers/blob/main/docs/ContainerCustomization.md).
+Out of the box, this package will infer a number of properties about the generated container image, including which base image to use, which version of that image to use, and where to push the generated image. You have control over all of these properties, however. You can read more about these customizations [here](https://aka.ms/dotnet/containers/customization).

--- a/Microsoft.NET.Build.Containers/README.md
+++ b/Microsoft.NET.Build.Containers/README.md
@@ -1,0 +1,18 @@
+# .NET SDK Containers
+
+This package lets you build container images from your projects with a single command.
+
+## Getting Started
+
+To build a container from the SDK, add this package and run the `publish` command,
+specifying the `DefaultContainer` PublishProfile. You can learn more about Publish Profiles [in the documentation](https://docs.microsoft.com/aspnet/core/host-and-deploy/visual-studio-publish-profiles?view=aspnetcore-6.0#publish-profiles).
+
+```shell
+>dotnet add package Microsoft.NET.Build.Containers --prerelease
+>dotnet publish --os linux --arch x64 -p:ProfileName=DefaultContainer
+...
+Pushed container '<your app name>:<your app version>' to registry 'docker://'
+...
+```
+
+Out of the box, this package will infer a number of properties about the generated container image, including which base image to use, which version of that image to use, and where to push the generated image. You have control over all of these properties, however. You can read more about these customizations [here](https://github.com/rainersigwald/containers/blob/main/docs/ContainerCustomization.md).

--- a/Microsoft.NET.Build.Containers/README.md
+++ b/Microsoft.NET.Build.Containers/README.md
@@ -16,3 +16,5 @@ Pushed container '<your app name>:<your app version>' to registry 'docker://'
 ```
 
 Out of the box, this package will infer a number of properties about the generated container image, including which base image to use, which version of that image to use, and where to push the generated image. You have control over all of these properties, however. You can read more about these customizations [here](https://aka.ms/dotnet/containers/customization).
+
+**Note**: This package only supports Linux containers in this version.

--- a/docs/ContainerCustomization.md
+++ b/docs/ContainerCustomization.md
@@ -32,7 +32,7 @@ Be default, we push to the local Docker daemon (annotated by `docker://`), but f
 ```
 
 > **Note**
-> There is no authentication currently supported - that will come in a future release - so make sure you're pointing to an unauthenticated registry
+> There is no authentication currently supported - that [will come in a future release](https://github.com/rainersigwald/containers/issues/70) - so make sure you're pointing to an unauthenticated registry
 
 ## ContainerImageName
 

--- a/docs/ContainerCustomization.md
+++ b/docs/ContainerCustomization.md
@@ -1,0 +1,84 @@
+# Customizing your container
+
+You can control many aspects of the generated container through MSBuild properties. In general, if you could use a command in a Dockerfile to set some configuration, you can do the same via MSBuild. 
+
+> **Note**
+> The only exception to this is `RUN` commands - due to the way we build containers, those cannot be emulated. If you need this functionality, you will need to use a Dockerfile to build your container images.
+
+## ContainerBaseImage
+
+This property controls the image used as the basis for your image. By default, we will infer the following values for you based on the properties of your project:
+
+* if your project is self-contained, we use the `mcr.microsoft.com/dotnet/runtime-deps` image as the base image
+* if your project is an ASP.NET Core project, we use the `mcr.microsoft.com/dotnet/aspnet` image as the base image
+* otherwise we use the `mcr.microsoft.com/dotnet/runtime` image as the base image
+
+We infer the tag of the image to be the numeric component of your chosen `TargetFramework` - so a `.net6.0` project will use the `6.0` tag of the inferred base image, a `.net7.0-linux` project will use the `7.0` tag, and so on.
+
+If you set a value here, you should set the fully-qualified name of the image to use as the base, including any tag you prefer:
+
+```xml
+<ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:6.0</ContainerBaseImage>
+```
+
+## ContainerRegistry
+
+This property controls the destination registry - the place that the newly-created image will be pushed to.
+
+Be default, we push to the local Docker daemon (annotated by `docker://`), but for this release you can specify any _unauthenticated_ registry. For example:
+
+```xml
+<ContainerRegistry>registry.mycorp.com:1234</ContainerRegistry>
+```
+
+> **Note**
+> There is no authentication currently supported - that will come in a future release - so make sure you're pointing to an unauthenticated registry
+
+## ContainerImageName
+
+This property controls the name of the image itself, e.g `dotnet/runtime` or `my-awesome-app`. 
+
+By default, the value used will be the `AssemblyName` of the project.
+
+
+```xml
+<ContainerImageName>my-super-awesome-app</ContainerImageName>
+```
+
+> **Note**
+> Image names can only contain lowercase alphanumeric characters, periods, underscores, and dashes, and must start with a letter or number - any other characters will result in an error being thrown.
+
+## ContainerImageTag
+
+This property controls the tag that is generated for the image. Tags are often used to refer to different versions of an application, but they can also refer to different operating system distributions, or even just different baked-in configuration.
+
+By default, the value used will be the `Version` of the project.
+
+```xml
+<ContainerImageTag>1.2.3-alpha2</ContainerImageTag>
+```
+
+> **Note**
+> Tags can only contain up to 127 alphanumeric characters, periods, underscores, and dashes. They must start with an alphanumeric character or an underscore. Any other form will result in an error being thrown.
+
+## ContainerWorkingDirectory
+
+This property controls the working directory of the container - the directory that commands are executed within if not other command is run.
+
+By default, we use the `/app` directory as the working directory.
+
+```xml
+<ContainerWorkingDirectory>/bin</ContainerWorkingDirectory>
+```
+
+## Unsupported properties
+
+There are many other properties and items that we want to add support for in subsequent previews:
+
+* Entrypoints
+* Entrypoint Arguments
+* Ports
+* Environment Variables
+* Labels
+
+We expect to add them in future versions, so watch this space!

--- a/docs/ContainerCustomization.md
+++ b/docs/ContainerCustomization.md
@@ -5,6 +5,9 @@ You can control many aspects of the generated container through MSBuild properti
 > **Note**
 > The only exception to this is `RUN` commands - due to the way we build containers, those cannot be emulated. If you need this functionality, you will need to use a Dockerfile to build your container images.
 
+> **Note**
+> This package only supports Linux containers in this version.
+
 ## ContainerBaseImage
 
 This property controls the image used as the basis for your image. By default, we will infer the following values for you based on the properties of your project:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,0 +1,14 @@
+# Getting Started
+
+To build a container from the SDK, add this package and run the `publish` command,
+specifying the `DefaultContainer` PublishProfile. You can learn more about Publish Profiles [in the documentation](https://docs.microsoft.com/aspnet/core/host-and-deploy/visual-studio-publish-profiles?view=aspnetcore-6.0#publish-profiles).
+
+```shell
+>dotnet add package Microsoft.NET.Build.Containers --prerelease
+>dotnet publish --os linux --arch x64 -p:ProfileName=DefaultContainer
+...
+Pushed container '<your app name>:<your app version>' to registry 'docker://'
+...
+```
+
+Out of the box, this package will infer a number of properties about the generated container image, including which base image to use, which version of that image to use, and where to push the generated image. You have control over all of these properties, however. You can read more about customizing the container [here](./ContainerCustomization.md)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -12,3 +12,6 @@ Pushed container '<your app name>:<your app version>' to registry 'docker://'
 ```
 
 Out of the box, this package will infer a number of properties about the generated container image, including which base image to use, which version of that image to use, and where to push the generated image. You have control over all of these properties, however. You can read more about customizing the container [here](./ContainerCustomization.md)
+
+> **Note**
+> This package only supports Linux containers in this version.


### PR DESCRIPTION
This adds a getting started and configuration set of documentation, as well as a README for the package. The package README is a slight repackaging of the docs\ content that links to it here as the authoritative source.

I also removed the repo-global packagerefs from the publicly-visible package dependencies.

Closes #78 