### PR TITLE
fix ref for main on pushes

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Get full repo history because versioning
+    - name: Get full repo history
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.push.sha }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Get full repo history because versioning
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.push.sha }}
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:


### PR DESCRIPTION
We need to actually clone the push target's history so that nerdbank works.