### PR TITLE
fix UsingTask declarations so that tasks can be consumed

### DIFF
--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.props
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.props
@@ -9,6 +9,6 @@
     </PropertyGroup>
 
     <!--Register our custom task-->
-    <UsingTask TaskName="$(MSBuildThisFileName).CreateNewImage" AssemblyFile="$(CustomTasksAssembly)"/>
-    <UsingTask TaskName="$(MSBuildThisFileName).ParseContainerProperties" AssemblyFile="$(CustomTasksAssembly)"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateNewImage" AssemblyFile="$(CustomTasksAssembly)"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ParseContainerProperties" AssemblyFile="$(CustomTasksAssembly)"/>
 </Project>

--- a/docs/INTEGRATED-DEMO.md
+++ b/docs/INTEGRATED-DEMO.md
@@ -20,7 +20,7 @@ dotnet nuget add source https://nuget.pkg.github.com/rainersigwald/index.json \
     --store-password-in-clear-text --configfile nuget.config
 
 # add a reference to the package
-dotnet add package Microsoft.NET.Build.Containers --version 0.1.3
+dotnet add package Microsoft.NET.Build.Containers --prerelease
 
 # publish your project
 dotnet publish --os linux --arch x64 -p:PublishProfile=DefaultContainer


### PR DESCRIPTION
After the namespace simplification, the UsingTask paths for the two tasks was incorrect.

I'm unsure why the tests I wrote didn't just blow up as a result of this, though.