### PR TITLE
Recursively walk input files to include in the container

### DIFF
--- a/Microsoft.NET.Build.Containers/Layer.cs
+++ b/Microsoft.NET.Build.Containers/Layer.cs
@@ -11,20 +11,14 @@ public record struct Layer
 
     public static Layer FromDirectory(string directory, string containerPath)
     {
-        DirectoryInfo di = new(directory);
-
-        IEnumerable<(string path, string containerPath)> fileList = 
-            di.GetFileSystemInfos()
-                .Where(fsi => fsi is FileInfo).Select(
-                fsi =>
-                {
-                    string destinationPath =
-                        Path.Join(containerPath,
-                            Path.GetRelativePath(directory, fsi.FullName))
-                        .Replace(Path.DirectorySeparatorChar, '/');
-                    return (fsi.FullName, destinationPath);
-                });
-
+        var fileList =
+            new DirectoryInfo(directory)
+            .EnumerateFiles("*", SearchOption.AllDirectories)
+            .Select(fsi =>
+                    {
+                        string destinationPath = Path.Join(containerPath, Path.GetRelativePath(directory, fsi.FullName)).Replace(Path.DirectorySeparatorChar, '/');
+                        return (fsi.FullName, destinationPath);
+                    });
         return FromFiles(fileList);
     }
 


### PR DESCRIPTION
Closes #109 

DirectoryInfo has a handy method to walk the entire tree from a starting directory, so we use that so that we don't miss anything.

Note that this isn't enough to make an `mvc` template app Just Work out of the box. I can exec onto the container and verify that the `wwwroot` folder exists, and that the contents of that folder match the publish outputs from a local build.

Unsure how to get the Static Files handler to log high enough to verify if this is our problem or something else.

Other things I noticed - even if the internal port on the container is 80, and ASPNETCORE_URLS is set to *:80, I _think_ the external port mapping of (for example) localhost:5010 results in routing mismatches, because the app is bound to :80, so it doesn't recognize the route.