### PR TITLE
Set image working directory

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -109,6 +109,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory);
         image.AddLayer(newLayer);
+        image.WorkingDirectory = WorkingDirectory;
         image.SetEntrypoint(Entrypoint.Select(i => i.ItemSpec).ToArray(), EntrypointArgs.Select(i => i.ItemSpec).ToArray());
 
         if (OutputRegistry.StartsWith("docker://"))


### PR DESCRIPTION
Many runtime properties are set off of the working directory of the process, including webapp content roots.