### PR TITLE
Add support for Labels to the Image config

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -66,6 +66,11 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
     /// </summary>
     public ITaskItem[] EntrypointArgs { get; set; }
 
+    /// <summary>
+    /// Labels that the image configuration will include in metadata
+    /// </summary>
+    public ITaskItem[] Labels { get; set; }
+
     public CreateNewImage()
     {
         BaseRegistry = "";
@@ -78,6 +83,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         WorkingDirectory = "";
         Entrypoint = Array.Empty<ITaskItem>();
         EntrypointArgs = Array.Empty<ITaskItem>();
+        Labels = Array.Empty<ITaskItem>();
     }
 
 
@@ -112,6 +118,11 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         image.WorkingDirectory = WorkingDirectory;
         image.SetEntrypoint(Entrypoint.Select(i => i.ItemSpec).ToArray(), EntrypointArgs.Select(i => i.ItemSpec).ToArray());
 
+        foreach (var label in Labels)
+        {
+            image.Label(label.ItemSpec, label.GetMetadata("Value"));
+        }
+        
         if (OutputRegistry.StartsWith("docker://"))
         {
             try

--- a/Microsoft.NET.Build.Containers/Image.cs
+++ b/Microsoft.NET.Build.Containers/Image.cs
@@ -17,7 +17,7 @@ public class Image
 
     internal List<Layer> newLayers = new();
 
-    public HashSet<Label> labels;
+    private HashSet<Label> labels;
 
     public Image(JsonNode manifest, JsonNode config, string name, Registry? registry)
     {
@@ -25,6 +25,7 @@ public class Image
         this.config = config;
         this.OriginatingName = name;
         this.originatingRegistry = registry;
+        // labels are inherited from the parent image, so we need to seed our new image with them.
         this.labels = ReadLabelsFromConfig(config);
     }
 

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -25,17 +25,20 @@
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>
-        
-        <ItemGroup>
-            <ContainerLabel Condition="@(ContainerLabel) == ''"></ContainerLabel>
+
+        <ItemGroup Label="Entrypoint Assignment">
             <!-- For non-apphosts, we need to invoke `dotnet` `workingdir/app` as separate args -->
             <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' != 'true'" Include="dotnet;$(ContainerWorkingDirectory)/$(TargetFileName)" />
             <!-- For apphosts, we need to invoke `workingdir/app` as a single arg -->
             <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' == 'true'" Include="$(ContainerWorkingDirectory)/$(AssemblyName)$(_NativeExecutableExtension)" />
         </ItemGroup>
 
+        <ItemGroup Label="Conventional Label assignment">
+            <ContainerLabel Include="org.opencontainers.image.created" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
+        </ItemGroup>
+
         <!-- Asp.NET defaults -->
-        <ItemGroup Condition="'$(_IsAspNet)' == 'true'">
+        <ItemGroup Label="ASP.NET port forwarding" Condition="'$(_IsAspNet)' == 'true'">
             <ContainerPort Include="80" Type="tcp" Condition="@(ContainerPort->WithMetadataValue('Identity', '80')->AnyHaveMetadataValue('Type', 'tcp')) == ''" />
 
             <ContainerEnvironmentVariable Include="ASPNETCORE_URLS" Value="http://localhost:5000;https://localhost:5001"

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -72,6 +72,7 @@
                         PublishDirectory="$(PublishDir)"
                         WorkingDirectory="$(ContainerWorkingDirectory)"
                         Entrypoint="@(ContainerEntrypoint)"
-                        EntrypointArgs="@(ContainerEntrypointArgs)"/>
+                        EntrypointArgs="@(ContainerEntrypointArgs)"
+						Labels="@(ContainerLabel)"/>
     </Target>
 </Project>


### PR DESCRIPTION
Adds support for `ContainerLabel` item group properties.

```
<ItemGroup>
  <ContainerLabel Include="com.microsoft.created-by" Value="dotnet-sdk" />
  <ContainerLabel Include="com.microsoft.project-name" Value="$(MSBuildProjectName)" />
</ItemGroup>
```